### PR TITLE
fix: Hide navigation on homepage for locale-based routes

### DIFF
--- a/app/components/Navigation.tsx
+++ b/app/components/Navigation.tsx
@@ -19,11 +19,6 @@ export default function Navigation() {
   const [faqLink, setFaqLink] = useState('/faq');
   const [aboutLink, setAboutLink] = useState('/about');
   
-  // 대시보드 페이지에서는 네비게이션 숨기기
-  if (pathname.startsWith('/dashboard')) {
-    return null;
-  }
-  
   useEffect(() => {
     if (pathname.includes('/guide')) {
       // Guide 페이지에서만 return 파라미터 추가
@@ -107,8 +102,13 @@ export default function Navigation() {
     return pathname.startsWith(href);
   };
 
-  // 홈페이지에서는 Navigation 숨김
-  if (pathname === '/') {
+  // 대시보드 페이지에서는 네비게이션 숨기기
+  if (pathname.startsWith('/dashboard')) {
+    return null;
+  }
+  
+  // 메인 페이지에서도 네비게이션 숨기기 (locale 포함)
+  if (pathname === `/${locale}` || pathname === '/' || pathname === '/ko' || pathname === '/en') {
     return null;
   }
 


### PR DESCRIPTION
## 🐛 Bug Fix

### Problem
- Navigation bar was showing on the homepage after i18n implementation
- Homepage should have a clean landing page without navigation

### Solution
- Hide navigation on locale-based homepage routes (/ko, /en)
- Fix React Hooks order error
- Keep navigation visible on all other pages

### Testing
- [x] Homepage shows no navigation
- [x] Other pages show navigation normally
- [x] No React Hooks errors