### PR TITLE
feat: Add language switcher button with country flags

### DIFF
--- a/app/components/HeaderControls.module.css
+++ b/app/components/HeaderControls.module.css
@@ -259,3 +259,67 @@
         font-size: 1rem;
     }
 }
+
+/* ============================= */
+/* Language Toggle Component Styles */
+/* ============================= */
+.languageToggle {
+    width: 44px;
+    height: 44px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: white;
+    border: 1px solid #e0e0e0;
+    border-radius: 8px;
+    cursor: pointer;
+    transition: var(--transition);
+    text-decoration: none;
+}
+
+.languageToggle:hover {
+    background: #f5f5f5;
+    border-color: #d0d0d0;
+    transform: scale(1.05);
+}
+
+.flagIcon {
+    font-size: 1.5rem;
+    line-height: 1;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+/* Dark mode language toggle */
+:global([data-theme="dark"]) .languageToggle {
+    background: var(--surface);
+    border-color: var(--border-color);
+}
+
+:global([data-theme="dark"]) .languageToggle:hover {
+    background: rgba(255, 255, 255, 0.1);
+}
+
+/* Mobile language toggle */
+@media (max-width: 767px) {
+    .languageToggle {
+        width: 40px;
+        height: 40px;
+    }
+    
+    .flagIcon {
+        font-size: 1.25rem;
+    }
+}
+
+@media (max-width: 767px) and (orientation: landscape) {
+    .languageToggle {
+        width: 36px;
+        height: 36px;
+    }
+    
+    .flagIcon {
+        font-size: 1.125rem;
+    }
+}

--- a/app/components/HeaderControls.tsx
+++ b/app/components/HeaderControls.tsx
@@ -2,6 +2,8 @@
 
 import React, { useEffect } from 'react';
 import { useTranslations } from 'next-intl';
+import { useRouter, usePathname, useParams } from 'next/navigation';
+import { Link } from '@/src/i18n/navigation';
 import { useThemeStore } from '@/app/lib/stores/themeStore';
 import { HeaderControlsProps } from '@/app/types';
 import styles from './HeaderControls.module.css';
@@ -21,6 +23,12 @@ export default function HeaderControls({
   
   // Use currentOS prop
   const displayOS = currentOS || 'mac';
+  
+  // i18n routing
+  const router = useRouter();
+  const pathname = usePathname();
+  const params = useParams();
+  const locale = params?.locale as string || 'en';
 
   // OS Toggle Handler
   const handleOSToggle = (os: 'mac' | 'windows') => {
@@ -93,6 +101,18 @@ export default function HeaderControls({
           <i className={`fas fa-${theme === 'light' ? 'moon' : 'sun'}`}></i>
         </button>
       )}
+
+      {/* Language Switcher */}
+      <Link
+        href={pathname.replace(`/${locale}`, '')}
+        locale={locale === 'ko' ? 'en' : 'ko'}
+        className={styles.languageToggle}
+        title={locale === 'ko' ? 'Switch to English' : '한국어로 전환'}
+      >
+        <span className={styles.flagIcon}>
+          {locale === 'ko' ? '🇺🇸' : '🇰🇷'}
+        </span>
+      </Link>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Added language toggle button next to theme switcher
- Shows appropriate country flags (🇰🇷/🇺🇸) based on current locale
- Includes hover animations and dark mode support

## Changes
- Updated HeaderControls.tsx to add language switching functionality
- Added styles for language toggle button in HeaderControls.module.css
- Button switches between Korean and English locales using next-intl Link component

## Visual
- Korean flag (🇰🇷) shown when in English mode (switches to Korean)
- US flag (🇺🇸) shown when in Korean mode (switches to English)
- Hover effect scales the button slightly for better UX
- Responsive design works on all device sizes